### PR TITLE
Fix app sorting in 'Pick an app' dialog

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
@@ -113,7 +113,7 @@ public class MainActivity extends AppsActivity {
         List<String> smallPackageNames = new ArrayList<>();
 
         List<ResolveInfo> activities = getActivities(packageManager);
-        Collections.sort(activities, Comparators.comparing(pm -> pm.loadLabel(packageManager).toString()));
+        Collections.sort(activities, Comparators.comparing(pm -> pm.loadLabel(packageManager).toString().toLowerCase()));
 
         for (ResolveInfo resolver : activities) {
             String appName = (String) resolver.loadLabel(packageManager);


### PR DESCRIPTION
The app list and the "Pick an app" dialog had different sorting where in the "Pick an app" dialog, apps starting with lowercase letters were sorted after Z:
![screenshot_2018-11-24-18-15-40](https://user-images.githubusercontent.com/925062/49007197-318e3c80-f16b-11e8-9b54-9c077eefb5df.png)

That of course does not make any sense, and in the all apps list apps like "andOTP" are correctly sorted up top:
![img_20181126_110033](https://user-images.githubusercontent.com/925062/49007196-318e3c80-f16b-11e8-8c37-1fe1f4033f8d.jpg)

So this is fixed in the "Pick an app" dialog now too. :)
![img_20181126_105954](https://user-images.githubusercontent.com/925062/49007194-318e3c80-f16b-11e8-978a-3d4d8c567a0a.jpg)

Please review @postapczuk @Poussinou
