### PR TITLE
Use dark theme for app picker

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
@@ -106,7 +106,7 @@ public class MainActivity extends AppsActivity {
     }
 
     private boolean showDialogWithApps(int position) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, AlertDialog.THEME_DEVICE_DEFAULT_DARK);
         builder.setTitle("Pick an app");
 
         List<String> smallAdapter = new ArrayList<>();


### PR DESCRIPTION
It was as simple as that. :slightly_smiling_face:  Now you can’t really see the age of the app anymore as it uses the default dark theme of the operating system:
![screenshot_2018-11-26-12-47-32](https://user-images.githubusercontent.com/925062/49012644-4c1be200-f17a-11e8-8c6c-2b6d181c0fa4.png)


Please review @postapczuk 