### PR TITLE
Move from margin to padding, swipe now works everywhere

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/AllAppsActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/AllAppsActivity.java
@@ -1,7 +1,6 @@
 package com.github.postapczuk.lalauncher;
 
 import android.os.Bundle;
-import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
@@ -16,8 +15,10 @@ public class AllAppsActivity extends AppsActivity {
         adapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, new ArrayList<String>());
         listView = prepareListView();
         setContentView(listView);
-        ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) listView.getLayoutParams();
-        layoutParams.leftMargin = 100;
+
+        // Set padding for all apps list
+        listView.setPadding(MainActivity.GlobalVars.getListPaddingLeft(), MainActivity.GlobalVars.getListPadding(), 0, MainActivity.GlobalVars.getListPadding());
+        listView.setClipToPadding(false);
     }
 
     @Override

--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static android.R.layout.simple_list_item_1;
-import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+import static android.view.ViewGroup.LayoutParams.FILL_PARENT;
 
 public class MainActivity extends AppsActivity {
 
@@ -49,13 +49,15 @@ public class MainActivity extends AppsActivity {
         listView = prepareListView();
         setContentView(listView);
 
+        // Set padding for favorite apps list
         ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) listView.getLayoutParams();
-        layoutParams.leftMargin = 100;
-        layoutParams.height = WRAP_CONTENT;
+        layoutParams.height = FILL_PARENT;
+        listView.setClipToPadding(false);
         WindowManager wm = (WindowManager) this.getSystemService(Context.WINDOW_SERVICE);
         if (wm != null) {
             Display display = wm.getDefaultDisplay();
-            layoutParams.topMargin = (display.getHeight()/2) - (getTotalHeightofListView()/2);
+            GlobalVars.setListPadding((display.getHeight() / 2) - (getTotalHeightofListView() / 2));
+            listView.setPadding(GlobalVars.getListPaddingLeft(), GlobalVars.getListPadding(), 0, 0);
         }
     }
 
@@ -166,5 +168,22 @@ public class MainActivity extends AppsActivity {
         }
         return totalHeight + (listView.getDividerHeight() * (adapter.getCount()));
 
+    }
+
+    public static class GlobalVars {
+        private static int listPadding = 100;
+        private static int listPaddingLeft = 100;
+
+        public static int getListPadding() {
+            return listPadding;
+        }
+
+        public static void setListPadding(int padding) {
+            listPadding = padding;
+        }
+
+        public static int getListPaddingLeft() {
+            return listPaddingLeft;
+        }
     }
 }


### PR DESCRIPTION
Now everything is done via padding instead of margin! :tada: 

This means that the swipe to reach the all apps view now works below (and above) the favorites list too.

On the main screen not a lot changed:
![Favorite apps](https://user-images.githubusercontent.com/925062/49014012-f564d700-f17e-11e8-8572-c6f599e4ca57.png)

In the all apps list I added the same padding as on the favorites screen for uniformity and to have an indicator of definite end:
![All apps list top](https://user-images.githubusercontent.com/925062/49014011-f4cc4080-f17e-11e8-9689-f0c0dea128f0.png)
Bottom:
![All apps list bottom](https://user-images.githubusercontent.com/925062/49014010-f4cc4080-f17e-11e8-8a61-08746ee0f257.png)

Please review @postapczuk :slightly_smiling_face: 