### PR TITLE
Fix error with low profile mode

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/AllAppsActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/AllAppsActivity.java
@@ -2,6 +2,7 @@ package com.github.postapczuk.lalauncher;
 
 import android.os.Build;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 


### PR DESCRIPTION
For some reason this did not came up during testing of "Dim system bars" https://github.com/postapczuk/Light-Android-Launcher/pull/18

But there was now some error with this change:
```
error: cannot find symbol variable View
```

This fixes that. :) Please review @postapczuk 