### PR TITLE
Set padding based on screen width instead of fixed value

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/MainActivity.java
@@ -58,6 +58,7 @@ public class MainActivity extends AppsActivity {
         if (wm != null) {
             Display display = wm.getDefaultDisplay();
             GlobalVars.setListPadding((display.getHeight() / 2) - (getTotalHeightofListView() / 2));
+            GlobalVars.setListPaddingLeft(display.getWidth() / 6);
             listView.setPadding(GlobalVars.getListPaddingLeft(), GlobalVars.getListPadding(), 0, 0);
         }
 
@@ -174,7 +175,6 @@ public class MainActivity extends AppsActivity {
             totalHeight += view.getMeasuredHeight();
         }
         return totalHeight + (listView.getDividerHeight() * (adapter.getCount()));
-
     }
 
     public static class GlobalVars {
@@ -191,6 +191,10 @@ public class MainActivity extends AppsActivity {
 
         public static int getListPaddingLeft() {
             return listPaddingLeft;
+        }
+
+        public static void setListPaddingLeft(int padding) {
+            listPaddingLeft = padding;
         }
     }
 }


### PR DESCRIPTION
The 100px we used were nice, but looked a bit strange on larger phones (looked good on my Moto G 1, but not so good on my Fairphone 2).

This fixes that, by just taking 1/6 of the screen width as left padding. :wink: 