### PR TITLE
Stop prompting to remove the Add Favourite button when long pressed

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/FavouriteAppsActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/FavouriteAppsActivity.java
@@ -157,6 +157,10 @@ public class FavouriteAppsActivity extends Activity {
 
     private void onLongPressHandler(ListView listView) {
         listView.setOnItemLongClickListener((parent, view, position, id) -> {
+            if (position == packageNames.size() || packageNames.get(position).equals("")) {
+                return true;
+            }
+
             toggleTextViewBackground(view, 350L);
             FavouriteAppsActivity favouriteAppsActivity = this;
 
@@ -171,8 +175,6 @@ public class FavouriteAppsActivity extends Activity {
                             }
                         });
                         alertDialog.show();
-
-
                     }
                     , 350L));
             return true;


### PR DESCRIPTION
This should satisfy #71 

When you long press the '+' or the '+ Add Favourite' item on the Favourites screen, it would prompt you to remove it as if it were an app. Hitting Yes didn't do anything but show a toast message that said Success (even though nothing actually happened).

So if the item being long pressed is the '+' item, just don't do anything.