### PR TITLE
Fix bug of system nav overlapping with app lists

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/FavouriteAppsActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/FavouriteAppsActivity.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static android.view.View.SYSTEM_UI_FLAG_LOW_PROFILE;
-import static android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS;
+import static android.view.WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN;
 
 public class FavouriteAppsActivity extends Activity {
 
@@ -49,9 +49,8 @@ public class FavouriteAppsActivity extends Activity {
             getWindow().getDecorView().setSystemUiVisibility(
                     SYSTEM_UI_FLAG_LOW_PROFILE);
         }
-        getWindow().setFlags(
-                FLAG_LAYOUT_NO_LIMITS,
-                FLAG_LAYOUT_NO_LIMITS);
+
+        getWindow().setFlags(FLAG_LAYOUT_IN_SCREEN, FLAG_LAYOUT_IN_SCREEN);
         setContentView(R.layout.activity_favourites);
         loadFavouritesFromPreferences();
         adapter = createNewAdapter();

--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/InstalledAppsActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/InstalledAppsActivity.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static android.view.Window.FEATURE_ACTIVITY_TRANSITIONS;
-import static android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS;
+import static android.view.WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN;
 
 public class InstalledAppsActivity extends Activity {
 
@@ -47,9 +47,7 @@ public class InstalledAppsActivity extends Activity {
             this.getWindow().requestFeature(
                     FEATURE_ACTIVITY_TRANSITIONS);
         }
-        this.getWindow().setFlags(
-                FLAG_LAYOUT_NO_LIMITS,
-                FLAG_LAYOUT_NO_LIMITS);
+        this.getWindow().setFlags(FLAG_LAYOUT_IN_SCREEN, FLAG_LAYOUT_IN_SCREEN);
         setContentView(R.layout.activity_installed);
 
         EditText editTextFilter = (EditText) findViewById(R.id.searchFilter);


### PR DESCRIPTION
The NO_LIMITS flags were causing the system navigation to draw
over top of the launcher's app list (favorites or the main list)

Should resolve #75