### PR TITLE
Fixed bug for onClick and onLongClick in InstalledApps

### DIFF
--- a/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/InstalledAppsActivity.java
+++ b/LaLauncher/src/main/java/com/github/postapczuk/lalauncher/InstalledAppsActivity.java
@@ -132,8 +132,7 @@ public class InstalledAppsActivity extends Activity {
     private void onClickHandler() {
         listView.setOnItemClickListener((parent, view, position, id) -> {
             toggleTextviewBackground(view, 100L);
-            String appName = parent.getItemAtPosition(position).toString();
-            String packageName = packageNames.get(appNamesPosition.indexOf(appName));
+            String packageName = packageNames.get(position);
             try {
                 startActivity(getPackageManager().getLaunchIntentForPackage(packageName));
             } catch (Exception e) {
@@ -150,10 +149,9 @@ public class InstalledAppsActivity extends Activity {
     private void onLongPressHandler() {
         listView.setOnItemLongClickListener((parent, view, position, id) -> {
             toggleTextviewBackground(view, 350L);
-            String appName = parent.getItemAtPosition(position).toString();
             try {
                 Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                intent.setData(Uri.parse("package:" + packageNames.get(appNamesPosition.indexOf(appName))));
+                intent.setData(Uri.parse("package:" + packageNames.get(position)));
                 startActivity(intent);
             } catch (ActivityNotFoundException e) {
                 fetchAppList();


### PR DESCRIPTION
We were taking the app name and using that to get the package name
of a given installed app. When doing this, if two apps had the same
name (or "label"), when we got the package name, it would always get
whichever one appeared first in packageNames. Instead, we can grab
the packageName using the position that already is passed in via the
onClick and onLongClick events to always grab the right one.

I noticed we were already grabbing the packageName in this way
in the FavouriteAppsActivity file.

Should resolve #78